### PR TITLE
fix: shortcodes render real author cards (not empty)

### DIFF
--- a/includes/Services/AuthorDataProvider.php
+++ b/includes/Services/AuthorDataProvider.php
@@ -201,26 +201,38 @@ class AuthorDataProvider implements Registerable {
 	 * @return array<string,mixed>
 	 */
 	private function normalize_user( WP_User $user ): array {
-		$socials = $this->meta_provider->get_meta( $user->ID, 'apbl_social_profiles', true );
-		$skills  = $this->meta_provider->get_meta( $user->ID, 'apbl_skills', true );
+		$socials      = $this->meta_provider->get_meta( $user->ID, 'apbl_social_profiles', true );
+		$skills       = $this->meta_provider->get_meta( $user->ID, 'apbl_skills', true );
+		$social_arr   = is_array( $socials ) ? $socials : array();
+		$avatar       = get_avatar_url( $user->ID, array( 'size' => 150 ) );
+		$avatar       = is_string( $avatar ) ? $avatar : '';
+		$member_label = (string) $this->meta_provider->get_meta( $user->ID, 'apbl_member_since_label', true );
+		$registered   = mysql2date( (string) get_option( 'date_format' ), $user->user_registered );
 
 		return array(
-			'id'            => $user->ID,
-			'name'          => $user->display_name,
-			'url'           => get_author_posts_url( $user->ID ),
-			'position'      => (string) $this->meta_provider->get_meta( $user->ID, 'apbl_author_position', true ),
-			'bio'           => $user->description,
-			'avatar_url'    => get_avatar_url( $user->ID, array( 'size' => 150 ) ),
-			'socials'       => is_array( $socials ) ? $socials : array(),
-			'department'    => (string) $this->meta_provider->get_meta( $user->ID, 'apbl_department', true ),
-			'skills'        => ! empty( $skills ) ? array_map( 'trim', explode( ',', (string) $skills ) ) : array(),
-			'location'      => (string) $this->meta_provider->get_meta( $user->ID, 'apbl_location', true ),
-			'phone'         => (string) $this->meta_provider->get_meta( $user->ID, 'apbl_phone', true ),
-			'availability'  => (string) $this->meta_provider->get_meta( $user->ID, 'apbl_availability', true ),
-			'website_label' => (string) $this->meta_provider->get_meta( $user->ID, 'apbl_website_label', true ),
-			'source'        => 'user',
-			'post_count'    => (int) count_user_posts( $user->ID ),
-			'joined'        => $user->user_registered,
+			'id'                 => $user->ID,
+			'name'               => $user->display_name,
+			'title'              => $user->display_name,
+			'url'                => get_author_posts_url( $user->ID ),
+			'email'              => $user->user_email,
+			'position'           => (string) $this->meta_provider->get_meta( $user->ID, 'apbl_author_position', true ),
+			'bio'                => $user->description,
+			'description'        => $user->description,
+			'avatar_url'         => $avatar,
+			'image'              => $avatar,
+			'socials'            => $social_arr,
+			'social'             => $social_arr,
+			'registered_date'    => is_string( $registered ) ? $registered : '',
+			'member_since_label' => '' !== $member_label ? $member_label : __( 'Member since', 'author-profile-blocks' ),
+			'department'         => (string) $this->meta_provider->get_meta( $user->ID, 'apbl_department', true ),
+			'skills'             => ! empty( $skills ) ? array_map( 'trim', explode( ',', (string) $skills ) ) : array(),
+			'location'           => (string) $this->meta_provider->get_meta( $user->ID, 'apbl_location', true ),
+			'phone'              => (string) $this->meta_provider->get_meta( $user->ID, 'apbl_phone', true ),
+			'availability'       => (string) $this->meta_provider->get_meta( $user->ID, 'apbl_availability', true ),
+			'website_label'      => (string) $this->meta_provider->get_meta( $user->ID, 'apbl_website_label', true ),
+			'source'             => 'user',
+			'post_count'         => (int) count_user_posts( $user->ID ),
+			'joined'             => $user->user_registered,
 		);
 	}
 
@@ -236,24 +248,35 @@ class AuthorDataProvider implements Registerable {
 		$terms       = get_the_terms( $post->ID, 'apbl_department' );
 		$department  = ! empty( $terms ) && ! is_wp_error( $terms ) ? $terms[0]->name : '';
 		$thumbnail   = get_the_post_thumbnail_url( $post->ID, 'thumbnail' );
+		$image       = is_string( $thumbnail ) ? $thumbnail : '';
+		$social_arr  = is_array( $socials ) ? $socials : array();
+		$bio         = wp_strip_all_tags( $post->post_content );
+		$registered  = mysql2date( (string) get_option( 'date_format' ), $post->post_date );
 
 		return array(
-			'id'            => $post->ID,
-			'name'          => $post->post_title,
-			'url'           => (string) get_permalink( $post ),
-			'position'      => (string) get_post_meta( $post->ID, 'apbl_tm_position', true ),
-			'bio'           => wp_strip_all_tags( $post->post_content ),
-			'avatar_url'    => is_string( $thumbnail ) ? $thumbnail : '',
-			'socials'       => is_array( $socials ) ? $socials : array(),
-			'department'    => $department,
-			'skills'        => array(),
-			'location'      => '',
-			'phone'         => '',
-			'availability'  => '',
-			'website_label' => '',
-			'source'        => 'team_member',
-			'post_count'    => 0,
-			'joined'        => $post->post_date,
+			'id'                 => $post->ID,
+			'name'               => $post->post_title,
+			'title'              => $post->post_title,
+			'url'                => (string) get_permalink( $post ),
+			'email'              => '',
+			'position'           => (string) get_post_meta( $post->ID, 'apbl_tm_position', true ),
+			'bio'                => $bio,
+			'description'        => $bio,
+			'avatar_url'         => $image,
+			'image'              => $image,
+			'socials'            => $social_arr,
+			'social'             => $social_arr,
+			'registered_date'    => is_string( $registered ) ? $registered : '',
+			'member_since_label' => __( 'Member since', 'author-profile-blocks' ),
+			'department'         => $department,
+			'skills'             => array(),
+			'location'           => '',
+			'phone'              => '',
+			'availability'       => '',
+			'website_label'      => '',
+			'source'             => 'team_member',
+			'post_count'         => 0,
+			'joined'             => $post->post_date,
 		);
 	}
 }

--- a/includes/Shortcodes/AuthorCarouselShortcode.php
+++ b/includes/Shortcodes/AuthorCarouselShortcode.php
@@ -67,6 +67,11 @@ class AuthorCarouselShortcode {
 			'apbl_carousel'
 		);
 
+		$block = author_profile_blocks()->get_block( 'author-carousel' );
+		if ( null === $block ) {
+			return '';
+		}
+
 		$include = ! empty( $atts['ids'] ) ? array_map( 'intval', explode( ',', $atts['ids'] ) ) : array();
 		$authors = $this->provider->get_authors(
 			array(
@@ -81,12 +86,45 @@ class AuthorCarouselShortcode {
 			return '';
 		}
 
-		ob_start();
-		$style    = sanitize_html_class( $atts['style'] );
-		$autoplay = 'true' === $atts['autoplay'];
-		foreach ( $authors as $author ) {
-			include APBL_PLUGIN_PATH . 'templates/blocks/author-carousel/slide.php';
+		// The carousel view script (Slick init) is registered by the block on wp_enqueue_scripts.
+		if ( wp_script_is( 'author-carousel-view', 'registered' ) ) {
+			wp_enqueue_script( 'author-carousel-view' );
 		}
+
+		$style      = sanitize_html_class( $atts['style'] );
+		$autoplay   = 'true' === $atts['autoplay'];
+		$attributes = array(
+			'layout'     => $style,
+			'autoplay'   => $autoplay,
+			'showSocial' => true,
+		);
+
+		$carousel_settings = array(
+			'slidesToShow'   => 3,
+			'slidesToScroll' => 1,
+			'autoplay'       => $autoplay,
+			'autoplaySpeed'  => 3000,
+			'dots'           => true,
+			'arrows'         => true,
+			'infinite'       => true,
+		);
+
+		$wrapper_attributes = sprintf(
+			'class="%s"',
+			esc_attr( 'wp-block-author-profile-blocks-author-carousel apbl-shortcode is-style-' . $style )
+		);
+
+		ob_start();
+		author_profile_blocks()->get_template(
+			'blocks/author-carousel/frontend.php',
+			array(
+				'authors'            => $authors,
+				'attributes'         => $attributes,
+				'block_instance'     => $block,
+				'wrapper_attributes' => $wrapper_attributes,
+				'carousel_settings'  => $carousel_settings,
+			)
+		);
 		return (string) ob_get_clean();
 	}
 }

--- a/includes/Shortcodes/AuthorGridShortcode.php
+++ b/includes/Shortcodes/AuthorGridShortcode.php
@@ -67,6 +67,11 @@ class AuthorGridShortcode {
 			'apbl_grid'
 		);
 
+		$block = author_profile_blocks()->get_block( 'author-grid' );
+		if ( null === $block ) {
+			return '';
+		}
+
 		$include = ! empty( $atts['ids'] ) ? array_map( 'intval', explode( ',', $atts['ids'] ) ) : array();
 		$authors = $this->provider->get_authors(
 			array(
@@ -81,12 +86,28 @@ class AuthorGridShortcode {
 			return '';
 		}
 
+		$style      = sanitize_html_class( $atts['style'] );
+		$attributes = array(
+			'layout'     => $style,
+			'columns'    => (int) $atts['columns'],
+			'showSocial' => true,
+		);
+
+		$wrapper_attributes = sprintf(
+			'class="%s"',
+			esc_attr( 'wp-block-author-profile-blocks-author-grid apbl-shortcode is-style-' . $style )
+		);
+
 		ob_start();
-		$columns = (int) $atts['columns'];
-		$style   = sanitize_html_class( $atts['style'] );
-		foreach ( $authors as $author ) {
-			include APBL_PLUGIN_PATH . 'templates/blocks/components/author-item.php';
-		}
+		author_profile_blocks()->get_template(
+			'blocks/author-grid/grid.php',
+			array(
+				'authors'            => $authors,
+				'attributes'         => $attributes,
+				'block_instance'     => $block,
+				'wrapper_attributes' => $wrapper_attributes,
+			)
+		);
 		return (string) ob_get_clean();
 	}
 }

--- a/includes/Shortcodes/AuthorListShortcode.php
+++ b/includes/Shortcodes/AuthorListShortcode.php
@@ -66,6 +66,11 @@ class AuthorListShortcode {
 			'apbl_list'
 		);
 
+		$block = author_profile_blocks()->get_block( 'author-list' );
+		if ( null === $block ) {
+			return '';
+		}
+
 		$include = ! empty( $atts['ids'] ) ? array_map( 'intval', explode( ',', $atts['ids'] ) ) : array();
 		$authors = $this->provider->get_authors(
 			array(
@@ -80,11 +85,29 @@ class AuthorListShortcode {
 			return '';
 		}
 
+		$style         = sanitize_html_class( $atts['style'] );
+		$display_style = in_array( $style, array( 'compact', 'detailed', 'minimal' ), true ) ? $style : 'detailed';
+		$attributes    = array(
+			'displayStyle'    => $display_style,
+			'showSocial'      => true,
+			'showSocialLinks' => true,
+		);
+
+		$wrapper_attributes = sprintf(
+			'class="%s"',
+			esc_attr( 'wp-block-author-profile-blocks-author-list apbl-shortcode is-style-' . $style )
+		);
+
 		ob_start();
-		$style = sanitize_html_class( $atts['style'] );
-		foreach ( $authors as $author ) {
-			include APBL_PLUGIN_PATH . 'templates/blocks/components/author-item.php';
-		}
+		author_profile_blocks()->get_template(
+			'blocks/author-list/list.php',
+			array(
+				'authors'            => $authors,
+				'attributes'         => $attributes,
+				'block_instance'     => $block,
+				'wrapper_attributes' => $wrapper_attributes,
+			)
+		);
 		return (string) ob_get_clean();
 	}
 }

--- a/includes/Shortcodes/AuthorProfileShortcode.php
+++ b/includes/Shortcodes/AuthorProfileShortcode.php
@@ -66,16 +66,42 @@ class AuthorProfileShortcode {
 			'apbl_profile'
 		);
 
+		$block = author_profile_blocks()->get_block( 'author-grid' );
+		if ( null === $block ) {
+			return '';
+		}
+
 		$author = $this->provider->get_author( (int) $atts['id'], $atts['source'] );
 		if ( ! $author ) {
 			return '';
 		}
 
+		if ( 'true' !== $atts['show_bio'] ) {
+			unset( $author['description'], $author['bio'] );
+		}
+
+		$style      = sanitize_html_class( $atts['style'] );
+		$attributes = array(
+			'layout'     => $style,
+			'columns'    => 1,
+			'showSocial' => 'true' === $atts['show_socials'],
+		);
+
+		$wrapper_attributes = sprintf(
+			'class="%s"',
+			esc_attr( 'wp-block-author-profile-blocks-author-profile apbl-shortcode is-style-' . $style )
+		);
+
 		ob_start();
-		$show_socials = 'true' === $atts['show_socials'];
-		$show_bio     = 'true' === $atts['show_bio'];
-		$style        = sanitize_html_class( $atts['style'] );
-		include APBL_PLUGIN_PATH . 'templates/blocks/components/author-item.php';
+		author_profile_blocks()->get_template(
+			'blocks/author-grid/grid.php',
+			array(
+				'authors'            => array( $author ),
+				'attributes'         => $attributes,
+				'block_instance'     => $block,
+				'wrapper_attributes' => $wrapper_attributes,
+			)
+		);
 		return (string) ob_get_clean();
 	}
 }

--- a/tests/php/src/Integration/Shortcodes/ShortcodeRenderTest.php
+++ b/tests/php/src/Integration/Shortcodes/ShortcodeRenderTest.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace AuthorProfileBlocks\Test\Integration\Shortcodes;
+
+use AuthorProfileBlocks\Test\Integration\IntegrationTestCase;
+
+/**
+ * Integration tests that render each shortcode end-to-end.
+ *
+ * Guards against the regression where shortcodes emitted empty cards because
+ * they included item templates without the pre-rendered component variables
+ * and fed them provider data in the wrong shape.
+ */
+class ShortcodeRenderTest extends IntegrationTestCase {
+
+	/**
+	 * Create a fully populated author including the core user description,
+	 * which the data provider (unlike the service) reads for the bio.
+	 *
+	 * @param string $display_name Display name.
+	 * @return int User ID.
+	 */
+	private function author( string $display_name ): int {
+		return $this->create_full_author(
+			array(
+				'display_name' => $display_name,
+				'description'  => 'Bio for ' . $display_name,
+			)
+		);
+	}
+
+	public function test_profile_shortcode_renders_single_author(): void {
+		$id   = $this->author( 'Alice' );
+		$html = \do_shortcode( '[apbl_profile id="' . $id . '"]' );
+
+		$this->assertNotEmpty( $html );
+		$this->assertStringContainsString( 'Alice', $html );
+		$this->assertStringContainsString( 'apbl-author-grid-item', $html );
+		$this->assertStringContainsString( 'wp-block-author-profile-blocks-author-profile', $html );
+	}
+
+	public function test_grid_shortcode_renders_authors_with_bio_and_social(): void {
+		$alice = $this->author( 'Alice' );
+		$bob   = $this->author( 'Bob' );
+
+		$html = \do_shortcode( '[apbl_grid ids="' . $alice . ',' . $bob . '" columns="2"]' );
+
+		$this->assertNotEmpty( $html );
+		$this->assertStringContainsString( 'apbl-author-grid', $html );
+		$this->assertStringContainsString( 'Alice', $html );
+		$this->assertStringContainsString( 'Bob', $html );
+		// Data-shape fix: description (bio) and social now reach the templates.
+		$this->assertStringContainsString( 'Bio for Alice', $html );
+		$this->assertStringContainsString( 'facebook.com/test', $html );
+	}
+
+	public function test_list_shortcode_renders_authors(): void {
+		$id   = $this->author( 'Carol' );
+		$html = \do_shortcode( '[apbl_list ids="' . $id . '"]' );
+
+		$this->assertNotEmpty( $html );
+		$this->assertStringContainsString( 'apbl-author-list', $html );
+		$this->assertStringContainsString( 'Carol', $html );
+	}
+
+	public function test_carousel_shortcode_renders_authors(): void {
+		$id   = $this->author( 'Dave' );
+		$html = \do_shortcode( '[apbl_carousel ids="' . $id . '"]' );
+
+		$this->assertNotEmpty( $html );
+		$this->assertStringContainsString( 'apbl-author-carousel', $html );
+		$this->assertStringContainsString( 'Dave', $html );
+	}
+
+	public function test_grid_shortcode_returns_empty_for_no_authors(): void {
+		$html = \do_shortcode( '[apbl_grid ids="999999999"]' );
+		$this->assertSame( '', $html );
+	}
+}

--- a/tests/php/src/Unit/Services/AuthorDataProviderTest.php
+++ b/tests/php/src/Unit/Services/AuthorDataProviderTest.php
@@ -34,7 +34,7 @@ class AuthorDataProviderTest extends AuthorProfileBlocksTestCase {
 		$content = file_get_contents(
 			TEST_AUTHOR_PROFILE_BLOCKS_PLUGIN_DIR . '/includes/Services/AuthorDataProvider.php'
 		);
-		foreach ( array( 'id', 'name', 'url', 'position', 'bio', 'avatar_url', 'socials', 'department', 'skills', 'location', 'source', 'post_count', 'joined' ) as $key ) {
+		foreach ( array( 'id', 'name', 'title', 'url', 'email', 'position', 'bio', 'description', 'avatar_url', 'image', 'socials', 'social', 'registered_date', 'member_since_label', 'department', 'skills', 'location', 'source', 'post_count', 'joined' ) as $key ) {
 			$this->assertStringContainsString( "'$key'", $content, "Missing key: $key" );
 		}
 	}


### PR DESCRIPTION
## Summary

The `[apbl_profile]`, `[apbl_grid]`, `[apbl_list]` and `[apbl_carousel]` shortcodes (and the widget path) rendered **empty cards plus PHP warnings**. Two root causes:

1. They `include`d the item templates (`author-item.php`, `slide.php`) raw, without the ten pre-rendered component variables those templates require (`$item_class`, `$author_image`, `$social_links`, …) — so `$layout` was undefined and every component var was empty.
2. They fed `AuthorDataProvider` data keyed `name`/`bio`/`avatar_url`/`socials`, but the templates read the service shape `title`/`image`/`description`/`social`.

## Fix

- Each shortcode now delegates to its registered **block instance** and renders the block's own container template (`grid.php` / `list.php` / `frontend.php`), which loops via `render_author_item()` / `render_author_slide()` — producing identical markup to the blocks.
- `[apbl_profile]` renders a single author through the grid container (`columns=1`), matching its original card-item intent. `team_member` sources still resolve via the provider (the service is user-only).
- `AuthorDataProvider` additively emits the canonical render keys (`title`, `image`, `description`, `email`, `social`, `registered_date`, `member_since_label`) so its data renders correctly through the shared component templates.

## Test plan

- [x] New `ShortcodeRenderTest` renders all four shortcodes; asserts non-empty markup incl. author name, bio (`Bio for Alice`) and social (`facebook.com/test`), plus empty-on-no-authors.
- [x] `composer test` — 362 tests pass (was 357).
- [x] PHPCS clean, PHPStan 0 errors.
- [ ] Manual: drop each shortcode on a page with real authors; confirm cards render and the carousel initializes.

## Notes

- **Stacked on #107** (base `fix/author-name-archive-link`) because it relies on that branch's shortcode template-path fix. Retarget to `trunk` once #107 merges.
- The provider keeps the old keys for backward-compatibility; redundant with the new aliases but low-risk.
- Out of scope (separate follow-ups identified in review): uninstall cleanup gated on an undefined constant; six REST user-meta fields with `__return_true` auth_callback; the `minimal` layout name not linking.