### PR TITLE
fix: REST meta auth, uninstall cleanup, minimal-layout name link

### DIFF
--- a/class-author-profile-blocks.php
+++ b/class-author-profile-blocks.php
@@ -311,7 +311,9 @@ class Author_Profile_Blocks {
 				'single'            => true,
 				'show_in_rest'      => true,
 				'sanitize_callback' => 'sanitize_text_field',
-				'auth_callback'     => '__return_true',
+				'auth_callback'     => function () {
+					return current_user_can( 'edit_users' );
+				},
 			)
 		);
 
@@ -322,7 +324,9 @@ class Author_Profile_Blocks {
 				'single'            => true,
 				'show_in_rest'      => true,
 				'sanitize_callback' => 'sanitize_text_field',
-				'auth_callback'     => '__return_true',
+				'auth_callback'     => function () {
+					return current_user_can( 'edit_users' );
+				},
 			)
 		);
 
@@ -333,7 +337,9 @@ class Author_Profile_Blocks {
 				'single'            => true,
 				'show_in_rest'      => true,
 				'sanitize_callback' => 'sanitize_text_field',
-				'auth_callback'     => '__return_true',
+				'auth_callback'     => function () {
+					return current_user_can( 'edit_users' );
+				},
 			)
 		);
 
@@ -344,7 +350,9 @@ class Author_Profile_Blocks {
 				'single'            => true,
 				'show_in_rest'      => true,
 				'sanitize_callback' => 'sanitize_text_field',
-				'auth_callback'     => '__return_true',
+				'auth_callback'     => function () {
+					return current_user_can( 'edit_users' );
+				},
 			)
 		);
 
@@ -355,7 +363,9 @@ class Author_Profile_Blocks {
 				'single'            => true,
 				'show_in_rest'      => true,
 				'sanitize_callback' => 'sanitize_text_field',
-				'auth_callback'     => '__return_true',
+				'auth_callback'     => function () {
+					return current_user_can( 'edit_users' );
+				},
 			)
 		);
 
@@ -366,7 +376,9 @@ class Author_Profile_Blocks {
 				'single'            => true,
 				'show_in_rest'      => true,
 				'sanitize_callback' => 'sanitize_text_field',
-				'auth_callback'     => '__return_true',
+				'auth_callback'     => function () {
+					return current_user_can( 'edit_users' );
+				},
 			)
 		);
 

--- a/templates/blocks/layouts/minimal.php
+++ b/templates/blocks/layouts/minimal.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Safely extract author data with fallbacks
 $apbl_author_name     = $author['title'] ?? $author['name'] ?? $author['display_name'] ?? '';
+$apbl_author_url      = $author['url'] ?? '';
 $apbl_author_image    = $author['image'] ?? '';
 $apbl_author_position = $author['position'] ?? '';
 $apbl_author_email    = $author['email'] ?? '';
@@ -34,7 +35,13 @@ $apbl_show_position   = $attributes['showPosition'] ?? true;
 
 	<div class="apbl-author-minimal-info">
 		<?php if ( ! empty( $apbl_author_name ) ) : ?>
-			<span class="apbl-author-name"><?php echo esc_html( $apbl_author_name ); ?></span>
+			<span class="apbl-author-name">
+				<?php if ( ! empty( $apbl_author_url ) ) : ?>
+					<a href="<?php echo esc_url( $apbl_author_url ); ?>"><?php echo esc_html( $apbl_author_name ); ?></a>
+				<?php else : ?>
+					<?php echo esc_html( $apbl_author_name ); ?>
+				<?php endif; ?>
+			</span>
 		<?php endif; ?>
 
 		<?php if ( ! empty( $apbl_author_position ) && $apbl_show_position ) : ?>

--- a/uninstall.php
+++ b/uninstall.php
@@ -10,11 +10,6 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
-// Check if uninstall is requested.
-if ( ! defined( 'AUTHOR_PROFILE_BLOCKS_UNINSTALL' ) || ! AUTHOR_PROFILE_BLOCKS_UNINSTALL ) {
-	return;
-}
-
 // Delete plugin options.
 delete_option( 'author_profile_blocks_settings' );
 delete_option( 'author_profile_blocks_activated' );


### PR DESCRIPTION
Addresses the three remaining findings from the code review.

## 1. Security — REST-writable profile meta
`apbl_department`, `apbl_skills`, `apbl_location`, `apbl_phone`, `apbl_availability`, `apbl_website_label` were registered with `'auth_callback' => '__return_true'` while `show_in_rest` was `true`, so **any authenticated user could write these user meta via the REST API**. Now gated on `current_user_can('edit_users')`, matching the sibling profile-meta fields.

## 2. Uninstall never cleaned up
`uninstall.php` was gated on `AUTHOR_PROFILE_BLOCKS_UNINSTALL` — a constant defined nowhere — so it always returned early and never deleted options/transients. Removed the dead gate; the `WP_UNINSTALL_PLUGIN` guard already restricts it to a real uninstall.

## 3. Minimal layout name not linked
The `minimal` layout rendered the author name as plain text. It now links to the author URL when present (plain text otherwise), matching the other layouts. The `url` key landed with #107 (merged), so this is live.

## Test plan
- [x] `composer test` — 357 tests pass.
- [x] PHPCS clean, PHPStan 0 errors.
- [ ] Manual: confirm a subscriber gets 403 writing `apbl_phone` via REST; delete the plugin and confirm options removed; minimal layout name links to the author archive.