### PR TITLE
chore(release): prepare 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-05-26
+
+### Security
+
+- Profile meta fields `apbl_department`, `apbl_skills`, `apbl_location`, `apbl_phone`, `apbl_availability` and `apbl_website_label` were registered with `auth_callback => __return_true` while `show_in_rest` was enabled, allowing any authenticated user to write them over the REST API. They now require the `edit_users` capability, matching the other profile meta fields.
+
+### Fixed
+
+- **Shortcodes rendered empty cards.** `[apbl_profile]`, `[apbl_grid]`, `[apbl_list]`, `[apbl_carousel]` and the Author Profile widget included item templates without their pre-rendered component variables and fed them author data in the wrong shape. They now delegate to the block rendering path and produce full author cards.
+- **Author names did not link.** The Author Profile, Grid, List and Carousel blocks now link author names to the author archive (WP users) or the team-member permalink; the `minimal` layout links too.
+- Shortcode template includes resolved to a non-existent `includes/templates/` path; they now resolve from the plugin root via `APBL_PLUGIN_PATH`.
+- The uninstall routine was gated on an undefined constant and never removed plugin options or transients; cleanup now runs on uninstall.
+- `AuthorProfileService::get_registered_date()` and the CSS color sanitizer now guard their `false`/`null` returns against their declared `string` return types.
+
+### Tests
+
+- 362 tests / 1002 assertions — all green. New: ShortcodeRenderTest renders all four shortcodes end-to-end.
+
 ## [1.1.0] - 2026-05-22
 
 ### Added

--- a/author-profile-blocks.php
+++ b/author-profile-blocks.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Author Profile Blocks
  * Plugin URI:        https://github.com/mralaminahamed/author-profile-blocks
  * Description:       Gutenberg blocks for displaying author profiles and team members with customizable layouts.
- * Version:           1.1.0
+ * Version:           1.1.1
  * Requires at least: 6.0
  * Tested up to:      6.9
  * Requires PHP:      7.4
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'APBL_VERSION', '1.1.0' );
+define( 'APBL_VERSION', '1.1.1' );
 define( 'APBL_PLUGIN_FILE', __FILE__ );
 define( 'APBL_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'APBL_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mralaminahamed/author-profile-blocks",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "A collection of powerful Gutenberg blocks for showcasing author profiles and team members using WordPress users.",
 	"author": "Al Amin Ahamed <mrabir.ahamed@gmail.com>",
 	"license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      mralaminahamed
 Tags:              block, gutenberg, author, profile, team
 Tested up to:      6.9
-Stable tag:        1.1.0
+Stable tag:        1.1.1
 Requires at least: 6.0
 Requires PHP:      7.4
 License:           GPL-2.0-or-later
@@ -158,6 +158,13 @@ Open an issue on [GitHub](https://github.com/mralaminahamed/author-profile-block
 5. Author List block — detailed display style with two-column image and bio layout.
 
 == Changelog ==
+
+= 1.1.1 =
+* Security: profile meta fields (department, skills, location, phone, availability, website label) were writable over REST by any authenticated user; they now require the edit_users capability.
+* Fix: shortcodes [apbl_profile], [apbl_grid], [apbl_list], [apbl_carousel] and the Author Profile widget rendered empty cards — they now render full author cards.
+* Fix: author names now link to the author archive (users) or team-member profile across the Author Profile, Grid, List, Carousel blocks and the minimal layout.
+* Fix: shortcode template includes pointed at a non-existent path; now resolved from the plugin root.
+* Fix: uninstall never removed plugin options/transients (gated on an undefined constant); cleanup now runs on uninstall.
 
 = 1.1.0 =
 * Add: Team Member CPT (`apbl_team_member`) — title, editor, thumbnail, menu-order; position and social profiles meta; REST-enabled.

--- a/tests/php/src/Integration/PluginTest.php
+++ b/tests/php/src/Integration/PluginTest.php
@@ -29,7 +29,7 @@ class PluginTest extends IntegrationTestCase {
 		$this->assertTrue( defined( 'APBL_PLUGIN_FILE' ) );
 		$this->assertTrue( defined( 'APBL_PLUGIN_PATH' ) );
 		$this->assertTrue( defined( 'APBL_PLUGIN_URL' ) );
-		$this->assertSame( '1.1.0', APBL_VERSION );
+		$this->assertSame( '1.1.1', APBL_VERSION );
 	}
 
 	public function test_register_blocks_registers_four_blocks(): void {


### PR DESCRIPTION
Version bump + changelog for the **1.1.1** patch/security release. All fixes are already on `trunk` (PRs #107–#110 merged); this PR only bumps the version and documents the release.

## Changes
- Version → `1.1.1` in plugin header, `APBL_VERSION`, `package.json`, readme `Stable tag`.
- `CHANGELOG.md` + `readme.txt` 1.1.1 entries.
- Update the pinned-version assertion in `PluginTest`.

## What 1.1.1 ships
- **Security**: REST-writable profile meta now requires `edit_users` (was `__return_true`).
- Shortcodes + widget render real author cards (were empty).
- Author names link to archive / team-member permalink (incl. minimal layout).
- Shortcode template paths resolve from plugin root.
- Uninstall actually removes options/transients.

## Test plan
- [x] `composer test` — 362 tests pass.
- [x] PHPCS clean, PHPStan 0 errors.
- [x] Version strings consistent across all four files.

## Release steps after merge (need go-ahead)
1. Merge this PR.
2. `composer release` (phpcs + phpstan + build + POT + zip).
3. Smoke-test the zip on a clean WP install.
4. Tag `v1.1.1` and deploy to WordPress.org.