### PR TITLE
Move 'More from us' into the Description

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -93,6 +93,25 @@ The plugin adds extra fields to the standard [WordPress user profile screen](htt
 * [PSR-4](https://www.php-fig.org/psr/psr-4/) autoloaded, [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/) compliant
 * Full [developer documentation on GitHub](https://github.com/mralaminahamed/author-profile-blocks#readme)
 
+= More from us =
+
+Other free plugins by the same author, all on WordPress.org.
+
+**For any site**
+
+* [Swift Menu Duplicator](https://wordpress.org/plugins/swift-menu-duplicator/) - Duplicate menus in one click, snapshot revisions, export and import, WP-CLI and REST.
+
+**For the WordPress AI Client**
+
+* [AI Provider for OpenCode Zen](https://wordpress.org/plugins/alamin-ai-provider-for-opencode-zen/) - One API key, 57 models including GPT-5, Claude and Gemini 3, for the WordPress AI Client.
+* [AI Provider for MiniMax](https://wordpress.org/plugins/alamin-ai-provider-for-minimax/) - MiniMax M2 and M3 models for text generation, for the WordPress AI Client.
+
+**For a WooCommerce store**
+
+* [StoreSeeder](https://wordpress.org/plugins/storeseeder/) - Realistic test data for WooCommerce and Fluent Cart — a whole shop from a recipe, with one-click cleanup.
+* [StoreSheet](https://wordpress.org/plugins/storesheet/) - Sync WooCommerce products, orders and coupons to a Google spreadsheet, one way and in the background.
+* [Warranty Cart](https://wordpress.org/plugins/warranty-cart/) - Sell extended warranties on your products, then handle the claims and renewals that follow.
+
 == Installation ==
 
 1. Upload the plugin folder to `/wp-content/plugins/`, or install via **Plugins → Add New**.
@@ -156,25 +175,6 @@ Open an issue on [GitHub](https://github.com/mralaminahamed/author-profile-block
 3. Author Grid block — multiple authors displayed in responsive 3-column card layout.
 4. Author Carousel block — sliding author cards with the modern-cards preset active.
 5. Author List block — detailed display style with two-column image and bio layout.
-
-== More from us ==
-
-Other free plugins by the same author, all on WordPress.org.
-
-**For any site**
-
-* [Swift Menu Duplicator](https://wordpress.org/plugins/swift-menu-duplicator/) - Duplicate menus in one click, snapshot revisions, export and import, WP-CLI and REST.
-
-**For the WordPress AI Client**
-
-* [AI Provider for OpenCode Zen](https://wordpress.org/plugins/alamin-ai-provider-for-opencode-zen/) - One API key, 57 models including GPT-5, Claude and Gemini 3, for the WordPress AI Client.
-* [AI Provider for MiniMax](https://wordpress.org/plugins/alamin-ai-provider-for-minimax/) - MiniMax M2 and M3 models for text generation, for the WordPress AI Client.
-
-**For a WooCommerce store**
-
-* [StoreSeeder](https://wordpress.org/plugins/storeseeder/) - Realistic test data for WooCommerce and Fluent Cart — a whole shop from a recipe, with one-click cleanup.
-* [StoreSheet](https://wordpress.org/plugins/storesheet/) - Sync WooCommerce products, orders and coupons to a Google spreadsheet, one way and in the background.
-* [Warranty Cart](https://wordpress.org/plugins/warranty-cart/) - Sell extended warranties on your products, then handle the claims and renewals that follow.
 
 == Changelog ==
 


### PR DESCRIPTION
It was a top-level `== More from us ==`, which the directory renders as its own corner of the page — past the changelog, below the fold, after the point anybody is still reading. Cross-links there are cross-links nobody follows.

The `== Description ==` is the plugin page: it is what renders under the banner, before the tabs. The block now sits at the end of it as a `=` sub-heading, so a reader meets it once they know what the plugin does and before they have to click anything.

Same content, same links — placement only.