### PR TITLE
Stop emptying SVN trunk mid-release, plus three smaller guards

### DIFF
--- a/.github/workflows/svn-cleanup.yml
+++ b/.github/workflows/svn-cleanup.yml
@@ -11,12 +11,15 @@ on:
         description: "Space-separated paths to delete (e.g. src docs README.md)"
         required: true
         default: "src docs"
+      # Defaults to a preview. This workflow deletes from the published SVN with credentials that can
+      # do it, and the form arrives pre-filled — so the button, pressed without reading, must not be
+      # the destructive one.
       dry_run:
         description: "Dry run — preview deletions without committing"
         required: false
-        default: "false"
+        default: "true"
         type: choice
-        options: ["false", "true"]
+        options: ["true", "false"]
 
 defaults:
   run:

--- a/.github/workflows/svn-deploy.yml
+++ b/.github/workflows/svn-deploy.yml
@@ -8,8 +8,11 @@ on:
 permissions:
   contents: write
 
+# Shared with the asset/readme workflow: both of these commit to the same SVN repository, and two
+# jobs holding a working copy of it at once is a conflict waiting to happen. Never cancel-in-progress
+# — an interrupted SVN commit is worse than a queued one.
 concurrency:
-  group: deploy-${{ github.ref }}
+  group: wporg-svn
   cancel-in-progress: false
 
 defaults:
@@ -190,38 +193,10 @@ jobs:
       - name: Install Subversion
         run: sudo apt-get update -y && sudo apt-get install -y subversion
 
-      - name: Clear pre-existing SVN trunk files before deploy
-        env:
-          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-          PLUGIN_SLUG:  ${{ needs.meta.outputs.plugin_slug }}
-        run: |
-          SVN_TRUNK="https://plugins.svn.wordpress.org/${PLUGIN_SLUG}/trunk"
-
-          svn checkout "$SVN_TRUNK" svn-trunk \
-            --username  "$SVN_USERNAME" \
-            --password  "$SVN_PASSWORD" \
-            --non-interactive --quiet
-
-          ITEMS=$(svn list svn-trunk | sed 's|/$||')
-
-          if [ -z "$ITEMS" ]; then
-            echo "SVN trunk is empty — nothing to clear."
-          else
-            echo "Clearing existing SVN trunk contents: $ITEMS"
-            for item in $ITEMS; do
-              svn delete "svn-trunk/${item}" --force --quiet
-            done
-            svn commit svn-trunk \
-              -m "chore: clear trunk before deploying v${{ needs.meta.outputs.version }}" \
-              --username "$SVN_USERNAME" \
-              --password "$SVN_PASSWORD" \
-              --non-interactive --quiet
-            echo "Trunk cleared."
-          fi
-
-          rm -rf svn-trunk
-
+      # Trunk is not emptied first. 10up's action diffs the build against trunk and svn-deletes what
+      # is no longer there, in the same commit that adds the new files — so clearing it beforehand
+      # bought nothing and cost a published revision in which the plugin had no files at all. Any
+      # failure between those two commits left it that way until somebody noticed.
       - name: Deploy plugin to WordPress.org via SVN
         id: deploy
         uses: 10up/action-wordpress-plugin-deploy@2.3.0

--- a/.github/workflows/svn-readme-assets-update.yml
+++ b/.github/workflows/svn-readme-assets-update.yml
@@ -9,9 +9,11 @@ on:
       - '.wordpress-org/**'
   workflow_dispatch:
 
+# Shared with the release workflow: both commit to the same SVN repository. Never
+# cancel-in-progress — an interrupted SVN commit is worse than a queued one.
 concurrency:
-  group: assets-deploy
-  cancel-in-progress: true
+  group: wporg-svn
+  cancel-in-progress: false
 
 jobs:
   sync:
@@ -20,8 +22,37 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # Tags are needed to resolve the published version; a shallow clone has none.
+          fetch-depth: 0
+
+      # `Stable tag` is the one line in readme.txt that trunk must not publish as written. WordPress
+      # serves downloads from /tags/<stable tag>/, so a readme naming a version that has not been
+      # released yet points the listing at a directory that does not exist, and it resolves to
+      # nothing. Everything else in the file is trunk's, which is the point of this workflow —
+      # correcting a listing should not require cutting a release.
+      - name: Pin Stable tag to the latest release tag
+        id: readme
+        run: |
+          set -euo pipefail
+
+          TAG="$(git tag --list --sort=-v:refname | head -n1)"
+
+          if [ -z "$TAG" ]; then
+            echo "::notice::No release tag yet — nothing to publish, leaving the directory alone."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          VERSION="${TAG#v}"
+          echo "::notice::Publishing trunk's readme.txt, Stable tag pinned to ${VERSION}"
+          # Keeps whatever spacing the header block uses — this readme aligns its values in a column.
+          sed -i -E "s/^(Stable tag:[[:space:]]*).*/\1${VERSION}/" readme.txt
+
+          grep -m1 '^Stable tag:' readme.txt
 
       - name: WordPress.org plugin asset/readme update
+        if: steps.readme.outputs.skip != 'true'
         uses: 10up/action-wordpress-plugin-asset-update@2.2.0
         env:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}


### PR DESCRIPTION
Four fixes to the WordPress.org publishing workflows, found while checking why this plugin's listing had gone stale.

### 1. The release emptied the published trunk before deploying

`svn-deploy.yml` checked out trunk, `svn delete`d every entry, **committed that**, and then ran the deploy. Between those two commits the plugin has no files on WordPress.org. Any failure in the second — action outage, artifact mismatch, an SVN hiccup — leaves it that way silently.

It also wasn't buying anything. `10up/action-wordpress-plugin-deploy` diffs the build against trunk and `svn delete`s what's no longer present, in the same commit that adds what is. Step removed; `Install Subversion` kept.

### 2. `svn-cleanup.yml` defaulted to deleting for real

`dry_run` defaulted to `"false"` and `paths` to `"src docs"`. Opening the dispatch form and pressing the green button — the whole interaction, done without reading — deleted `src` and `docs` from live SVN and committed. Now defaults to `"true"`, with `"true"` first in the options list.

### 3. The asset sync published trunk's `Stable tag` verbatim

WordPress serves downloads from `/tags/<stable tag>/`. A readme that names a version not yet tagged points the listing at a directory that does not exist — this is what broke storeseeder's listing (fixed there in mralaminahamed/storeseeder#122). Trunk and the newest tag agree today (1.1.1 / v1.1.1), so this is a guard, not a repair.

`Stable tag` alone is rewritten; the rest of readme.txt is trunk's, so a listing can still be corrected without cutting a release. The `sed` preserves the header block's column alignment — verified against this repo's readme, output byte-identical to the current file.

### 4. The two SVN writers could run concurrently

`deploy-${{ github.ref }}` and `assets-deploy` are different groups, so a tag push and a trunk push each got a working copy of the same SVN repository. Both now use `wporg-svn`, neither cancels in progress — an interrupted SVN commit is worse than a queued one.

All three files parse (`YAML.load_file`).