### PR TITLE
Aim the listing at the searches it can win

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
-=== Author Profile Blocks ===
+=== Author Profile Blocks – Author Box & Team Members for Gutenberg ===
 Contributors:      mralaminahamed
-Tags:              block, gutenberg, author, profile, team
+Tags:              author box, author bio, team members, author profile, gutenberg
 Tested up to:      6.9
 Stable tag:        1.1.1
 Requires at least: 6.0


### PR DESCRIPTION
The title was `Author Profile Blocks` — 21 characters, in the most heavily weighted field in the index, naming neither "author box" nor "team members". Tags were five generic single words.

- **Title** — `Author Profile Blocks – Author Box & Team Members for Gutenberg`
- **Tags** — `author box, author bio, team members, author profile, gutenberg`

**The honest part:** this plugin does not appear in the top 50 for any of those terms and this change probably will not move that. `author box` has 1,989 competitors led by simple-author-box at 90,000 installs; `team members block` is led by plugins in the millions. The directory ranks on installs and ratings, and this has zero of both. What the change fixes is a listing that did not name the things it is — which matters when somebody does land on it, and costs nothing.