### PR TITLE
The documented seed teardown never ran

### DIFF
--- a/.wordpress-org/BRAND.md
+++ b/.wordpress-org/BRAND.md
@@ -106,9 +106,9 @@ social links, and four pages — one per block. Everything carries
 `_apbl_demo_seed`, so `--remove` deletes what was seeded and nothing else:
 
 ```bash
-wp eval-file resources/dev/seed.php -- --list             # the scopes
-wp eval-file resources/dev/seed.php -- --only=authors     # one of them
-wp eval-file resources/dev/seed.php -- --remove           # all of it, backwards
+wp eval-file resources/dev/seed.php list                  # the scopes
+wp eval-file resources/dev/seed.php only=authors          # one of them
+wp eval-file resources/dev/seed.php remove                # all of it, backwards
 ```
 
 It also sets `avatar_default` to `identicon` and restores the previous value on

--- a/resources/dev/seed.php
+++ b/resources/dev/seed.php
@@ -6,10 +6,16 @@
  * the data behind them is. This creates the authors and the pages the capture
  * run photographs, and can take all of it away again.
  *
- *   wp eval-file resources/dev/seed.php                    # everything
- *   wp eval-file resources/dev/seed.php -- --remove        # undo everything
- *   wp eval-file resources/dev/seed.php -- --list          # what the scopes are
- *   wp eval-file resources/dev/seed.php -- --only=authors  # one scope
+ *   wp eval-file resources/dev/seed.php                 # everything
+ *   wp eval-file resources/dev/seed.php remove          # undo everything
+ *   wp eval-file resources/dev/seed.php list            # what the scopes are
+ *   wp eval-file resources/dev/seed.php only=authors    # one scope
+ *
+ * The arguments carry no dashes on purpose. WP-CLI parses dash-prefixed words
+ * as its own parameters before the script sees them, so `-- --remove` fails
+ * with "unknown --remove parameter" and nothing runs. Dashed forms are still
+ * accepted if you type them, but they only reach here in WP-CLI versions that
+ * pass them through.
  *
  * Scopes run in dependency order: settings → authors → pages. Removal runs it
  * backwards, because a page that displays authors is meaningless once they are
@@ -125,17 +131,35 @@ const APBL_AUTHORS = array(
  * @return array{remove: bool, list: bool, only: string}
  */
 function apbl_seed_flags( array $args ): array {
-	$only = '';
+	$only   = '';
+	$remove = false;
+	$list   = false;
 
 	foreach ( $args as $arg ) {
-		if ( 0 === strpos( $arg, '--only=' ) ) {
-			$only = substr( $arg, 7 );
+		// Leading dashes are stripped before comparing. `wp eval-file` hands
+		// this script whatever follows the filename, but WP-CLI parses
+		// dash-prefixed words as its own parameters first — `-- --remove` fails
+		// with "unknown --remove parameter" and the script never runs.
+		$word = ltrim( $arg, '-' );
+
+		if ( 0 === strpos( $word, 'only=' ) ) {
+			$only = substr( $word, 5 );
+			continue;
+		}
+
+		if ( 'remove' === $word ) {
+			$remove = true;
+			continue;
+		}
+
+		if ( 'list' === $word ) {
+			$list = true;
 		}
 	}
 
 	return array(
-		'remove' => in_array( '--remove', $args, true ),
-		'list'   => in_array( '--list', $args, true ),
+		'remove' => $remove,
+		'list'   => $list,
 		'only'   => $only,
 	);
 }


### PR DESCRIPTION
`wp eval-file resources/dev/seed.php -- --remove` fails:

```
Error: Parameter errors:
 unknown --remove parameter
```

WP-CLI parses dash-prefixed words as its own parameters before `eval-file` passes anything on, so the script is never reached. It exits and the demo data stays exactly where it was — which looks identical to a clean teardown if you are not reading the output.

Arguments are bare words now: `remove`, `list`, `only=authors`. Dashes are stripped before comparing, so the dashed forms still work anywhere WP-CLI passes them through.

Verified both directions on a live site: `list` prints the scopes, `only=<scope>` runs one, `remove` unwinds in reverse.

Found while capturing screenshots for vendor-tasks-dokan-clickup, whose seed was copied from this one and carried the same defect. Fixed there in mralaminahamed/vendor-tasks-dokan-clickup#27.