### PR TITLE
Drop classmap-authoritative, which makes every new class a fatal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,6 @@
       "ergebnis/composer-normalize": true,
       "phpstan/extension-installer": true
     },
-    "classmap-authoritative": true,
     "optimize-autoloader": true,
     "platform": {
       "php": "7.4"


### PR DESCRIPTION
`classmap-authoritative` tells Composer the generated classmap is the **complete** list of classes in the project, so the PSR-4 map is never consulted. Any class added since the last `dump-autoload` is invisible, and the failure is a fatal on load:

```
Uncaught Error: Class "..." not found
```

The class is there, in the right namespace, at the path `autoload.psr-4` points to. The autoloader simply does not look.

**Scope:** releases regenerate the map, so shipped builds are unaffected. Developer checkouts are — clone, `composer install`, white screen — as is any CI job whose composer cache restores a `vendor/` built from an older commit, since `composer install` then has nothing to do.

`optimize-autoloader` stays. It builds the same classmap; it just doesn't claim to be exhaustive. The common path is still a hash lookup, and a class the map hasn't caught up with still loads.

This was found the hard way: the fatal stopped a screenshot run in mralaminahamed/vendor-tasks-dokan-clickup#28, where it was verified that a class absent from `autoload_classmap.php` resolves through PSR-4 once the flag is gone and does not before. This repo carries the identical pair of settings, so it is the same latent fault.